### PR TITLE
Reset do not disturb

### DIFF
--- a/common/src/main/java/de/michelinside/glucodatahandler/common/notification/AlarmNotificationBase.kt
+++ b/common/src/main/java/de/michelinside/glucodatahandler/common/notification/AlarmNotificationBase.kt
@@ -701,6 +701,7 @@ abstract class AlarmNotificationBase: NotifierInterface, SharedPreferences.OnSha
             if(lastRingerMode >= 0 ) {
                 Log.i(LOG_ID, "Reset ringer mode to $lastRingerMode")
                 audioManager.ringerMode = lastRingerMode
+                Channels.getNotificationManager().setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_ALL)
                 lastRingerMode = -1
             }
             if(lastDndMode != NotificationManager.INTERRUPTION_FILTER_UNKNOWN) {


### PR DESCRIPTION
Fixes #188

Reset the interruption filter to all after resetting the ringer mode.
This should fix the issue. If do not disturb was disabled it will be disabled again.
If do not disturb was in another state it will be reset to the previous state by the following logic of lastDndMode.