### PR TITLE
Add Aidex to notification filter list

### DIFF
--- a/common/src/main/java/de/michelinside/glucodatahandler/common/receiver/NotificationReceiver.kt
+++ b/common/src/main/java/de/michelinside/glucodatahandler/common/receiver/NotificationReceiver.kt
@@ -175,6 +175,8 @@ class NotificationReceiver : NotificationListenerService(), NamedReceiver {
             return true
         if(packageName.lowercase().startsWith("com.medtronic."))  // MiniMed has 5 min interval
             return true
+        if(packageName.lowercase().startsWith("com.microtechmd.cgms")) // Aidex has 5 minute interval
+            return true
         // else
         return sharedPref.getBoolean(Constants.SHARED_PREF_SOURCE_NOTIFICATION_READER_5_MINUTE_INTERVAl, true)
     }

--- a/common/src/main/java/de/michelinside/glucodatahandler/common/utils/PackageUtils.kt
+++ b/common/src/main/java/de/michelinside/glucodatahandler/common/utils/PackageUtils.kt
@@ -165,6 +165,7 @@ object PackageUtils {
             receiverFilter.add("com.medtrum.")  // Medtrum
             receiverFilter.add("com.signos.")  // Signos
             receiverFilter.add("com.gluroo.")  // Gluroo
+            receiverFilter.add("com.microtechmd.cgms") // Aidex CGM
         }
         return receiverFilter
     }


### PR DESCRIPTION
Notification for Aidex is functionally identical to LinX, as both are the same manufacturer. Added to filter list and added to hardcoded 5 minute list, as it's a 5 minute CGM. 

Note: Parsing notifications from apps not in the filter list will only work when the device's screen is on, as Android does not seem to render full 'bigData' notifications on the lock screen. 