### PR TITLE
Receive glucodata.Minute.eIOB from Juggluco NG

### DIFF
--- a/common/src/main/java/de/michelinside/glucodatahandler/common/ReceiveData.kt
+++ b/common/src/main/java/de/michelinside/glucodatahandler/common/ReceiveData.kt
@@ -34,6 +34,7 @@ object ReceiveData: SharedPreferences.OnSharedPreferenceChangeListener {
     const val TIME = "glucodata.Minute.Time"
     const val DELTA = "glucodata.Minute.Delta"
     const val IOB = "glucodata.Minute.IOB"
+    const val EIOB = "glucodata.Minute.eIOB"
     const val COB = "glucodata.Minute.COB"
     const val IOBCOB_TIME = "gdh.IOB_COB_time"
     const val SENSOR_START_TIME = "gdh.sensor_start_time"
@@ -92,6 +93,7 @@ object ReceiveData: SharedPreferences.OnSharedPreferenceChangeListener {
     }
 
     var iob: Float = Float.NaN
+    var eiob: Float = Float.NaN
     var cob: Float = Float.NaN
     var iobCobTime: Long = 0
     private var lowValue: Float = 70F
@@ -239,6 +241,8 @@ object ReceiveData: SharedPreferences.OnSharedPreferenceChangeListener {
         if(withIobCob && !isIobCobObsolete()) {
             if(!iob.isNaN())
                 text += ", " + context.getString(R.string.info_label_iob_talkback) + " " + getIobAsString()
+            if(!eiob.isNaN())
+                text += ", " + context.getString(R.string.info_label_eiob_talkback) + " " + getEiobAsString()
             if(!cob.isNaN())
                 text += ", " + context.getString(R.string.info_label_cob_talkback) + " " + getCobAsString()
         }
@@ -330,6 +334,7 @@ object ReceiveData: SharedPreferences.OnSharedPreferenceChangeListener {
     private fun isIobCob() : Boolean {
         if (isIobCobObsolete()) {
             iob = Float.NaN
+            eiob = Float.NaN
             cob = Float.NaN
         }
         return !iob.isNaN() || !cob.isNaN()
@@ -356,6 +361,21 @@ object ReceiveData: SharedPreferences.OnSharedPreferenceChangeListener {
         if (withUnit)
             return iobString + " U"
         return iobString
+    }
+
+    val eiobString: String get() {
+        if (isIobCobObsolete())
+            eiob = Float.NaN
+        if(eiob.isNaN()) {
+            return " - "
+        }
+        return "%.2f".format(Locale.ROOT, eiob)
+    }
+
+    fun getEiobAsString(withUnit: Boolean = true): String {
+        if (withUnit)
+            return eiobString + " U"
+        return eiobString
     }
     fun getCobAsString(withUnit: Boolean = true): String {
         if (withUnit)
@@ -678,6 +698,7 @@ object ReceiveData: SharedPreferences.OnSharedPreferenceChangeListener {
 
                     if(extras.containsKey(IOB) || extras.containsKey(COB)) {
                         iob = extras.getFloat(IOB, Float.NaN)
+                        eiob = extras.getFloat(EIOB, Float.NaN)
                         cob = extras.getFloat(COB, Float.NaN)
                         iobCobTime = if(extras.containsKey(IOBCOB_TIME))
                             extras.getLong(IOBCOB_TIME)
@@ -769,6 +790,7 @@ object ReceiveData: SharedPreferences.OnSharedPreferenceChangeListener {
             if(iob != extras.getFloat(IOB, Float.NaN) || cob != extras.getFloat(COB, Float.NaN)) {
                 Log.i(LOG_ID, "Only IOB/COB changed: ${extras.getFloat(IOB, Float.NaN)}/${extras.getFloat(COB, Float.NaN)} - at ${Utils.getUiTimeStamp(iobCobTime)} - from $dataSource")
                 iob = extras.getFloat(IOB, Float.NaN)
+                eiob = extras.getFloat(EIOB, Float.NaN)
                 cob = extras.getFloat(COB, Float.NaN)
                 iobCobChange = true
             } else {
@@ -933,6 +955,7 @@ object ReceiveData: SharedPreferences.OnSharedPreferenceChangeListener {
         extras.putFloat(DELTA, deltaValue)
         if(includeObsoleteIobCob || !isIobCobObsolete()) {
             extras.putFloat(IOB, iob)
+            extras.putFloat(EIOB, eiob)
             extras.putFloat(COB, cob)
             extras.putLong(IOBCOB_TIME, iobCobTime)
         }
@@ -982,6 +1005,7 @@ object ReceiveData: SharedPreferences.OnSharedPreferenceChangeListener {
                 putInt(ALARM, alarm)
                 putFloat(DELTA, deltaValue)
                 putFloat(IOB, iob)
+                putFloat(EIOB, eiob)
                 putFloat(COB, cob)
                 putLong(IOBCOB_TIME, iobCobTime)
                 putInt(DELTA_FALLING_COUNT, deltaFallingCount)
@@ -1014,6 +1038,7 @@ object ReceiveData: SharedPreferences.OnSharedPreferenceChangeListener {
                     extras.putInt(ALARM, sharedGlucosePref.getInt(ALARM, alarm))
                     extras.putFloat(DELTA, sharedGlucosePref.getFloat(DELTA, deltaValue))
                     extras.putFloat(IOB, sharedGlucosePref.getFloat(IOB, iob))
+                    extras.putFloat(EIOB, sharedGlucosePref.getFloat(EIOB, eiob))
                     extras.putFloat(COB, sharedGlucosePref.getFloat(COB, cob))
                     extras.putLong(IOBCOB_TIME, sharedGlucosePref.getLong(IOBCOB_TIME, iobCobTime))
                     extras.putInt(DELTA_FALLING_COUNT, sharedGlucosePref.getInt(DELTA_FALLING_COUNT, deltaFallingCount))
@@ -1088,6 +1113,7 @@ object ReceiveData: SharedPreferences.OnSharedPreferenceChangeListener {
             startTimePair = Pair("", 0L)
             iobCobTime = 0L
             iob = Float.NaN
+            eiob = Float.NaN
             cob = Float.NaN
             deltaFallingCount = 0
             deltaRisingCount = 0

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -11,7 +11,9 @@
 
     <string name="info_label_iob" translatable="false">IOB</string>
     <string name="info_label_cob" translatable="false">COB</string>
+    <string name="info_label_eiob" translatable="false">eIOB</string>
     <string name="info_label_iob_talkback" translatable="false">I.O.B.</string>
+    <string name="info_label_eiob_talkback" translatable="false">effective I.O.B.</string>
     <string name="info_label_cob_talkback" translatable="false">C.O.B.</string>
 
     <string name="menu_facebook" translatable="false">Facebook</string>

--- a/mobile/src/main/java/de/michelinside/glucodatahandler/MainActivity.kt
+++ b/mobile/src/main/java/de/michelinside/glucodatahandler/MainActivity.kt
@@ -1037,6 +1037,8 @@ class MainActivity : AppCompatActivity(), NotifierInterface {
             if (!ReceiveData.isIobCobObsolete(1.days.inWholeSeconds.toInt()))
                 tableDetails.addView(createRow(CR.string.info_label_iob_cob_timestamp, DateFormat.getTimeInstance(
                     DateFormat.DEFAULT).format(Date(ReceiveData.iobCobTime))))
+            if (!ReceiveData.eiob.isNaN() && !ReceiveData.isIobCobObsolete())
+                tableDetails.addView(createRow(CR.string.info_label_eiob, ReceiveData.getEiobAsString()))
             if (ReceiveData.sensorID?.isNotEmpty() == true) {
                 if(ReceiveData.source == DataSource.AAPS)
                     tableDetails.addView(createRow(CR.string.label_profile, ReceiveData.sensorID!!))


### PR DESCRIPTION
JugglucoNG (a Juggluco fork) recently started filling the IOB/COB extras of the glucodata.Minute broadcast from its insulin journal (ctqvva/JugglucoNG#76), and it sends one additional key next to them: glucodata.Minute.eIOB. That's remaining insulin weighted by its current activity, basically how much of the IOB is actually working right now. Starts at 0 after a bolus, equals IOB at the activity peak, never exceeds it, same action curves underneath.

This makes GDH keep the value instead of dropping it: parsed and stored next to iob in ReceiveData with the same obsolescence handling, forwarded through createExtras like iob (wear/auto), persisted and restored with the other extras, exposed via eiobString / getEiobAsString, and shown as a row in the mobile details table plus talkback, only when present.

Sources that don't send the key see no change. The field stays NaN, hasNewIobCob is untouched, all display additions are NaN-guarded. I deliberately left widgets, watch faces and the car view alone, happy to add it wherever you'd want it.

Heads up: I couldn't build this locally, common/build.gradle expects DEXCOM_APPLICATION_ID and friends from a gradle.properties that isn't in the repo, so CI has to judge the compile. The changes mirror the existing iob code paths line by line though, and I run the sending side (JugglucoNG) with GDH on my own phone, the standard IOB/COB extras arrive and display fine.
